### PR TITLE
Add managed release feed provider

### DIFF
--- a/Examples/AppUpdaterExample/AppUpdaterExample/AppUpdaterHelper.swift
+++ b/Examples/AppUpdaterExample/AppUpdaterExample/AppUpdaterHelper.swift
@@ -8,28 +8,132 @@
 import Foundation
 import AppUpdater
 
-class AppUpdaterHelper {
-    
-    static let shared = AppUpdaterHelper()
-    
-    let appUpdater: AppUpdater
-    
-    init() {
-        let useMock = UserDefaults.standard.bool(forKey: "useMockProvider")
-        if useMock {
-            let mock = MockReleaseProvider()
-            let updater = AppUpdater(owner: "mock", repo: "mock", releasePrefix: "AppUpdaterExample", interval: 3 * 60 * 60, proxy: nil, provider: mock)
-            updater.skipCodeSignValidation = true
-            updater.enableDebugInfo = true
-            self.appUpdater = updater
-        } else {
-            let updater = AppUpdater(owner: "s1ntoneli", repo: "AppUpdater-Test", releasePrefix: "AppUpdaterExample", interval: 3 * 60 * 60)
-            updater.enableDebugInfo = true
-            self.appUpdater = updater
+enum ExampleProviderMode: String, CaseIterable, Identifiable {
+    case github
+    case managed
+    case mock
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .github:
+            return "GitHub"
+        case .managed:
+            return "Managed Feed"
+        case .mock:
+            return "Mock"
         }
+    }
+
+    var description: String {
+        switch self {
+        case .github:
+            return "Fetches releases directly from GitHub Releases."
+        case .managed:
+            return "Fetches releases from a backend feed and exposes entitlement / policy metadata."
+        case .mock:
+            return "Runs fully offline using bundled mock release data."
+        }
+    }
+}
+
+final class AppUpdaterHelper {
+    static let shared = AppUpdaterHelper()
+
+    static let providerModeKey = "providerMode"
+    static let legacyUseMockProviderKey = "useMockProvider"
+    static let managedFeedURLKey = "managedFeedURL"
+    static let managedLicenseKey = "managedLicenseKey"
+    static let managedDeviceIDKey = "managedDeviceID"
+
+    static let defaultManagedFeedURL = "https://example.com/api/public/app-updates/feed"
+    static let defaultManagedLicenseKey = "EXAMPLE-LICENSE"
+    static let defaultManagedDeviceID = "example-device-id"
+
+    let appUpdater: AppUpdater
+
+    init() {
+        let updater = AppUpdater(
+            owner: "s1ntoneli",
+            repo: "AppUpdater-Test",
+            releasePrefix: "AppUpdaterExample",
+            interval: 3 * 60 * 60,
+            proxy: nil,
+            provider: GithubReleaseProvider()
+        )
+        updater.enableDebugInfo = true
+        self.appUpdater = updater
+        applyStoredConfiguration()
     }
 
     func initialize() {
         appUpdater.allowPrereleases = UserDefaults.standard.bool(forKey: "betaUpdates")
+        applyStoredConfiguration()
+    }
+
+    func applyStoredConfiguration() {
+        configure(appUpdater, with: Self.currentProviderMode())
+    }
+
+    func updateProviderMode(_ mode: ExampleProviderMode) {
+        UserDefaults.standard.set(mode.rawValue, forKey: Self.providerModeKey)
+        UserDefaults.standard.set(mode == .mock, forKey: Self.legacyUseMockProviderKey)
+        configure(appUpdater, with: mode)
+    }
+
+    func updateManagedConfiguration(feedURL: String, licenseKey: String, deviceID: String) {
+        UserDefaults.standard.set(feedURL, forKey: Self.managedFeedURLKey)
+        UserDefaults.standard.set(licenseKey, forKey: Self.managedLicenseKey)
+        UserDefaults.standard.set(deviceID, forKey: Self.managedDeviceIDKey)
+        if Self.currentProviderMode() == .managed {
+            configure(appUpdater, with: .managed)
+        }
+    }
+
+    static func currentProviderMode() -> ExampleProviderMode {
+        if let raw = UserDefaults.standard.string(forKey: providerModeKey),
+           let mode = ExampleProviderMode(rawValue: raw) {
+            return mode
+        }
+        if UserDefaults.standard.bool(forKey: legacyUseMockProviderKey) {
+            return .mock
+        }
+        return .github
+    }
+
+    static func storedManagedFeedURL() -> String {
+        UserDefaults.standard.string(forKey: managedFeedURLKey) ?? defaultManagedFeedURL
+    }
+
+    static func storedManagedLicenseKey() -> String {
+        UserDefaults.standard.string(forKey: managedLicenseKey) ?? defaultManagedLicenseKey
+    }
+
+    static func storedManagedDeviceID() -> String {
+        UserDefaults.standard.string(forKey: managedDeviceIDKey) ?? defaultManagedDeviceID
+    }
+
+    private func configure(_ updater: AppUpdater, with mode: ExampleProviderMode) {
+        updater.provider = makeProvider(for: mode)
+        updater.skipCodeSignValidation = mode == .mock
+    }
+
+    private func makeProvider(for mode: ExampleProviderMode) -> ReleaseProvider {
+        switch mode {
+        case .github:
+            return GithubReleaseProvider()
+        case .managed:
+            let url = URL(string: Self.storedManagedFeedURL())
+                ?? URL(string: Self.defaultManagedFeedURL)!
+            return ManagedReleaseProvider(
+                feedURL: url,
+                licenseProvider: { Self.storedManagedLicenseKey() },
+                deviceIdProvider: { Self.storedManagedDeviceID() },
+                platform: "macos"
+            )
+        case .mock:
+            return MockReleaseProvider()
+        }
     }
 }

--- a/Examples/AppUpdaterExample/AppUpdaterExample/ContentView.swift
+++ b/Examples/AppUpdaterExample/AppUpdaterExample/ContentView.swift
@@ -11,14 +11,20 @@ import AppUpdater
 struct ContentView: View {
     @EnvironmentObject
     var appUpdater: AppUpdater
-    
+
     @State
     private var router: Routers = .general
     @State
-    private var useMockProvider: Bool = UserDefaults.standard.bool(forKey: "useMockProvider")
+    private var providerMode: ExampleProviderMode = AppUpdaterHelper.currentProviderMode()
     @State
     private var languagesText: String = ""
-    
+    @State
+    private var managedFeedURL: String = AppUpdaterHelper.storedManagedFeedURL()
+    @State
+    private var managedLicenseKey: String = AppUpdaterHelper.storedManagedLicenseKey()
+    @State
+    private var managedDeviceID: String = AppUpdaterHelper.storedManagedDeviceID()
+
     var body: some View {
         NavigationView {
             List {
@@ -26,7 +32,7 @@ struct ContentView: View {
                     Routers.appupdater.LinkTo {
                         AppUpdateSettings()
                     }
-                    .modifier( stateBadgeModifier )
+                    .modifier(stateBadgeModifier)
                 }
                 Section {
                     Routers.general.LinkTo {
@@ -47,54 +53,119 @@ struct ContentView: View {
         }
         .onAppear { applyProviderFromDefaults() }
     }
-    
+
     @ViewBuilder
     func GeneralSettings() -> some View {
-        Text("General Settings")
-        Toggle("Use Mock Data", isOn: $useMockProvider)
-            .onChange(of: useMockProvider) { newValue in
-                UserDefaults.standard.set(newValue, forKey: "useMockProvider")
-                if newValue {
-                    appUpdater.provider = MockReleaseProvider()
-                    appUpdater.skipCodeSignValidation = true
-                } else {
-                    appUpdater.provider = GithubReleaseProvider()
-                    appUpdater.skipCodeSignValidation = false
+        Form {
+            Section("Provider") {
+                Picker("Source", selection: $providerMode) {
+                    ForEach(ExampleProviderMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: providerMode) { newValue in
+                    AppUpdaterHelper.shared.updateProviderMode(newValue)
+                }
+
+                Text(providerMode.description)
+                    .foregroundStyle(.secondary)
+            }
+
+            if providerMode == .managed {
+                Section("Managed Feed") {
+                    TextField("Feed URL", text: $managedFeedURL)
+                        .textFieldStyle(.roundedBorder)
+                    TextField("License Key", text: $managedLicenseKey)
+                        .textFieldStyle(.roundedBorder)
+                    TextField("Device ID", text: $managedDeviceID)
+                        .textFieldStyle(.roundedBorder)
+                    HStack {
+                        Button("Apply Managed Settings") {
+                            AppUpdaterHelper.shared.updateManagedConfiguration(
+                                feedURL: managedFeedURL,
+                                licenseKey: managedLicenseKey,
+                                deviceID: managedDeviceID
+                            )
+                        }
+                        Spacer()
+                        Button("Reset Defaults") {
+                            managedFeedURL = AppUpdaterHelper.defaultManagedFeedURL
+                            managedLicenseKey = AppUpdaterHelper.defaultManagedLicenseKey
+                            managedDeviceID = AppUpdaterHelper.defaultManagedDeviceID
+                            AppUpdaterHelper.shared.updateManagedConfiguration(
+                                feedURL: managedFeedURL,
+                                licenseKey: managedLicenseKey,
+                                deviceID: managedDeviceID
+                            )
+                        }
+                    }
+                    Text("Use this mode to simulate a production app where the backend returns releases plus entitlement and policy metadata.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
                 }
             }
-        Text("Provider: \(useMockProvider ? "Mock" : "GitHub")")
-        HStack {
-            Text("Changelog Languages (priority order):")
-            TextField("e.g., zh-Hans, en", text: $languagesText)
-                .textFieldStyle(.roundedBorder)
-                .frame(maxWidth: 320)
-            Button("Apply") {
-                let langs = languagesText.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-                appUpdater.preferredChangelogLanguages = langs
+
+            Section("Changelog") {
+                HStack {
+                    Text("Languages")
+                    TextField("e.g., zh-Hans, en", text: $languagesText)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 320)
+                    Button("Apply") {
+                        let langs = languagesText.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+                        appUpdater.preferredChangelogLanguages = langs
+                    }
+                    Button("Use System") {
+                        languagesText = Locale.preferredLanguages.joined(separator: ", ")
+                        appUpdater.preferredChangelogLanguages = Locale.preferredLanguages
+                    }
+                }
             }
-            Button("Use System") {
-                languagesText = Locale.preferredLanguages.joined(separator: ", ")
-                appUpdater.preferredChangelogLanguages = Locale.preferredLanguages
+
+            Section("Managed Feed State") {
+                if let entitlement = appUpdater.entitlement {
+                    Text("Entitlement: \(entitlement.statusCode)")
+                    Text(entitlement.statusMessage)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("No entitlement metadata loaded")
+                        .foregroundStyle(.secondary)
+                }
+
+                if appUpdater.notices.isEmpty {
+                    Text("No feed notices loaded")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(Array(appUpdater.notices.enumerated()), id: \.offset) { _, notice in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(notice.code)
+                                .font(.caption.weight(.semibold))
+                            Text(notice.message)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+
+            Section {
+                Button {
+                    appUpdater.check()
+                } label: {
+                    Text("Check Updates")
+                }
             }
         }
-        Button {
-            appUpdater.check()
-        } label: {
-            Text("Check Updates")
-        }
+        .formStyle(.grouped)
     }
 
-    /// Ensure the toggle reflects and applies provider on appear
     func applyProviderFromDefaults() {
-        let newValue = UserDefaults.standard.bool(forKey: "useMockProvider")
-        useMockProvider = newValue
-        if newValue {
-            appUpdater.provider = MockReleaseProvider()
-            appUpdater.skipCodeSignValidation = true
-        } else {
-            appUpdater.provider = GithubReleaseProvider()
-            appUpdater.skipCodeSignValidation = false
-        }
+        providerMode = AppUpdaterHelper.currentProviderMode()
+        managedFeedURL = AppUpdaterHelper.storedManagedFeedURL()
+        managedLicenseKey = AppUpdaterHelper.storedManagedLicenseKey()
+        managedDeviceID = AppUpdaterHelper.storedManagedDeviceID()
+        AppUpdaterHelper.shared.applyStoredConfiguration()
     }
 }
 
@@ -102,39 +173,39 @@ enum Routers {
     case general
     case about
     case license
-    
+
     case appupdater
-    
+
     var name: String {
         switch self {
         case .general:
             return "General"
-        
+
         case .appupdater:
             return "Software Updates Available"
-            
+
         case .about:
             return "About"
         case .license:
             return "License"
         }
     }
-    
+
     var icon: String {
         switch self {
         case .general:
             return "gear"
-            
+
         case .appupdater:
             return ""
-            
+
         case .about:
             return "info"
         case .license:
             return "checkmark.seal.fill"
         }
     }
-    
+
     var iconBgColor: Color {
         switch self {
         case .general:
@@ -147,14 +218,14 @@ enum Routers {
             return Color.accentColor
         }
     }
-    
+
     @ViewBuilder func LinkTo(_ destination: () -> some View) -> some View {
         NavigationLink(destination: destination()) {
             SidebarLabel(name: self.name, icon: self.icon, color: self.iconBgColor)
         }
         .tag(self)
     }
-    
+
     @ViewBuilder
     func SidebarLabel(name: String, icon: String, color: Color) -> some View {
         HStack(spacing: 6) {

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,10 @@ let package = Package(
         .executableTarget(
             name: "AppUpdaterMockRunner",
             dependencies: ["AppUpdater"]
+        ),
+        .testTarget(
+            name: "AppUpdaterTests",
+            dependencies: ["AppUpdater"]
         )
     ]
 )

--- a/README-zh.md
+++ b/README-zh.md
@@ -84,10 +84,13 @@ updater.skipCodeSignValidation = true // 使用 Mock 时建议跳过签名校验
 ## 托管 Feed Provider
 
 - `ManagedReleaseProvider` 允许你继续沿用 `AppUpdater` 现有的检查、下载、安装流程，但把 release 数据源改成你自己的后端 feed，而不是直接请求 GitHub Releases API。
+- 这个模式适合“App 是否可更新”和“会员功能是否可用”需要分开表达的产品。
 - 它期望的响应结构仍然是 `{ success, data, error }`，其中 `data.releases` 继续保持 GitHub release 风格，并可以额外包含：
   - `entitlement`：会员/功能可用状态摘要
   - `policy`：单个版本安装后的策略摘要
   - `notices`：供 UI 直接展示的提示列表
+
+典型初始化方式如下：
 
 ```swift
 let updater = AppUpdater(
@@ -106,6 +109,7 @@ let updater = AppUpdater(
   - `updater.entitlement`
   - `updater.notices`
 - `Release` 也会解码可选的 `policy` 字段，这样无需改下载主路径，也能在现有更新 UI 中展示“安装后会员功能是否可用”的说明。
+- 完整接入说明见 [docs/managed-feed-provider.zh.md](docs/managed-feed-provider.zh.md)。
 
 ## 本地化（Localization）
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -109,7 +109,7 @@ let updater = AppUpdater(
   - `updater.entitlement`
   - `updater.notices`
 - `Release` 也会解码可选的 `policy` 字段，这样无需改下载主路径，也能在现有更新 UI 中展示“安装后会员功能是否可用”的说明。
-- 完整接入说明见 [docs/managed-feed-provider.zh.md](docs/managed-feed-provider.zh.md)。
+- 完整接入说明见 [docs/managed-feed-provider.zh.md](docs/managed-feed-provider.zh.md)，其中包含宿主 App 接入清单和 Swift 示例。
 
 ## 本地化（Localization）
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -81,6 +81,32 @@ updater.skipCodeSignValidation = true // 使用 Mock 时建议跳过签名校验
   - 多语言更新说明附件：包内的 `CHANGELOG.<lang>.md`
   - 模拟下载：`MockReleaseProvider.download` 按进度流式输出，并生成最小 `.app` 压缩包。
 
+## 托管 Feed Provider
+
+- `ManagedReleaseProvider` 允许你继续沿用 `AppUpdater` 现有的检查、下载、安装流程，但把 release 数据源改成你自己的后端 feed，而不是直接请求 GitHub Releases API。
+- 它期望的响应结构仍然是 `{ success, data, error }`，其中 `data.releases` 继续保持 GitHub release 风格，并可以额外包含：
+  - `entitlement`：会员/功能可用状态摘要
+  - `policy`：单个版本安装后的策略摘要
+  - `notices`：供 UI 直接展示的提示列表
+
+```swift
+let updater = AppUpdater(
+    owner: "ignored",
+    repo: "ignored",
+    provider: ManagedReleaseProvider(
+        feedURL: URL(string: "https://example.com/api/public/app-updates/feed")!,
+        licenseProvider: { licenseKey },
+        deviceIdProvider: { deviceId },
+        platform: "macos"
+    )
+)
+```
+
+- `AppUpdater` 会把托管 feed 的附加状态发布到：
+  - `updater.entitlement`
+  - `updater.notices`
+- `Release` 也会解码可选的 `policy` 字段，这样无需改下载主路径，也能在现有更新 UI 中展示“安装后会员功能是否可用”的说明。
+
 ## 本地化（Localization）
 
 - UI 文案：`AppUpdaterSettings` 已本地化（英文、简体中文）。如需新增语言，在 `Sources/AppUpdater/Resources` 下添加 `*.lproj/Localizable.strings`。

--- a/README.md
+++ b/README.md
@@ -84,10 +84,13 @@ updater.skipCodeSignValidation = true // recommended when using mocks
 ## Managed Feed Provider
 
 - `ManagedReleaseProvider` keeps the existing `AppUpdater` download/install flow, but sources releases from your own backend feed instead of the GitHub Releases API.
+- This mode is useful when update delivery and premium-feature availability are separate concerns.
 - The expected response format remains `{ success, data, error }`, where `data.releases` still looks like GitHub releases and can additionally include:
   - `entitlement`: membership or feature availability summary
   - `policy`: per-release post-install policy summary
   - `notices`: top-level notices for UI display
+
+A typical setup looks like this:
 
 ```swift
 let updater = AppUpdater(
@@ -106,6 +109,7 @@ let updater = AppUpdater(
   - `updater.entitlement`
   - `updater.notices`
 - `Release` now also decodes an optional `policy` payload, so existing update UIs can show post-install membership messaging without changing the download path.
+- See [docs/managed-feed-provider.md](docs/managed-feed-provider.md) for the full integration mode, backend response shape, and responsibilities split.
 
 ## Localization
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ updater.skipCodeSignValidation = true // recommended when using mocks
   - Changelog attachments: `CHANGELOG.<lang>.md` files in package resources
   - Simulated download: `MockReleaseProvider.download` streams progress and outputs a minimal `.app` inside a zip/tar as needed.
 
+## Managed Feed Provider
+
+- `ManagedReleaseProvider` keeps the existing `AppUpdater` download/install flow, but sources releases from your own backend feed instead of the GitHub Releases API.
+- The expected response format remains `{ success, data, error }`, where `data.releases` still looks like GitHub releases and can additionally include:
+  - `entitlement`: membership or feature availability summary
+  - `policy`: per-release post-install policy summary
+  - `notices`: top-level notices for UI display
+
+```swift
+let updater = AppUpdater(
+    owner: "ignored",
+    repo: "ignored",
+    provider: ManagedReleaseProvider(
+        feedURL: URL(string: "https://example.com/api/public/app-updates/feed")!,
+        licenseProvider: { licenseKey },
+        deviceIdProvider: { deviceId },
+        platform: "macos"
+    )
+)
+```
+
+- `AppUpdater` exposes the extra managed-feed state through:
+  - `updater.entitlement`
+  - `updater.notices`
+- `Release` now also decodes an optional `policy` payload, so existing update UIs can show post-install membership messaging without changing the download path.
+
 ## Localization
 
 - UI strings in `AppUpdaterSettings` are localized (English, Simplified Chinese). You may contribute more locales via `Sources/AppUpdater/Resources`.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ let updater = AppUpdater(
   - `updater.entitlement`
   - `updater.notices`
 - `Release` now also decodes an optional `policy` payload, so existing update UIs can show post-install membership messaging without changing the download path.
-- See [docs/managed-feed-provider.md](docs/managed-feed-provider.md) for the full integration mode, backend response shape, and responsibilities split.
+- See [docs/managed-feed-provider.md](docs/managed-feed-provider.md) for the full integration mode, a host-app checklist, and concrete Swift examples.
 
 ## Localization
 

--- a/Sources/AppUpdater/AppUpdater.swift
+++ b/Sources/AppUpdater/AppUpdater.swift
@@ -39,6 +39,14 @@ public class AppUpdater: ObservableObject {
     @MainActor
     @Published public var releases: [Release] = []
 
+    /// entitlement summary from a managed feed provider
+    @MainActor
+    @Published public var entitlement: ManagedReleaseFeed.Entitlement?
+
+    /// notices from a managed feed provider
+    @MainActor
+    @Published public var notices: [ManagedReleaseFeed.Notice] = []
+
     /// last error captured for diagnostics
     @MainActor
     @Published public var lastError: Swift.Error?
@@ -223,6 +231,7 @@ public class AppUpdater: ObservableObject {
         trace("fetched releases count:", releases.count)
 
         notifyReleasesDidChange(releases)
+        syncManagedFeedIfNeeded()
 
         guard let (release, asset) = try releases.findViableUpdate(appVersion: currentVersion, releasePrefix: self.releasePrefix, prerelease: self.allowPrereleases) else {
             trace("no viable update for", currentVersion.description, "prefix", self.releasePrefix, "prerelease", self.allowPrereleases)
@@ -278,6 +287,20 @@ public class AppUpdater: ObservableObject {
     private func notifyReleasesDidChange(_ releases: [Release]) {
         Task { @MainActor in
             self.releases = releases
+        }
+    }
+
+    private func syncManagedFeedIfNeeded() {
+        if let provider = provider as? ManagedReleaseFeedProviding {
+            Task { @MainActor in
+                self.entitlement = provider.lastFeed?.entitlement
+                self.notices = provider.lastFeed?.notices ?? []
+            }
+        } else {
+            Task { @MainActor in
+                self.entitlement = nil
+                self.notices = []
+            }
         }
     }
 
@@ -400,6 +423,7 @@ public struct Release: Decodable {
     public let assets: [Asset]
     public let body: String
     public let name: String
+    public let policy: ManagedReleasePolicy?
     
     let html_url: String
     public var htmlUrl: String { html_url }
@@ -410,6 +434,7 @@ public struct Release: Decodable {
         case assets
         case body
         case name
+        case policy
         case html_url
     }
     
@@ -420,6 +445,7 @@ public struct Release: Decodable {
         self.assets = try container.decode([Release.Asset].self, forKey: .assets)
         self.body = try container.decode(String.self, forKey: .body)
         self.name = try container.decode(String.self, forKey: .name)
+        self.policy = try container.decodeIfPresent(ManagedReleasePolicy.self, forKey: .policy)
         self.html_url = try container.decode(String.self, forKey: .html_url)
     }
 

--- a/Sources/AppUpdater/AppUpdaterSettings.swift
+++ b/Sources/AppUpdater/AppUpdaterSettings.swift
@@ -69,6 +69,16 @@ public struct AppUpdateSettings: View {
                                     }
                                 }
                             }
+                            if let entitlement = updater.entitlement {
+                                Text(entitlement.statusMessage)
+                                    .font(.callout)
+                                    .foregroundStyle(entitlement.memberFeaturesActive ? Color.secondary : Color.orange)
+                            }
+                            if let policyMessage = updater.state.release?.policy?.message {
+                                Text(policyMessage)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
                             /// changelog
                             LocalizedChangelogView(release: updater.state.release)
                         }
@@ -78,6 +88,14 @@ public struct AppUpdateSettings: View {
                             Text(NSLocalizedString("More Info...", bundle: .module, comment: ""))
                         }
                         .buttonStyle(.link)
+                    }
+                }
+                if !updater.notices.isEmpty {
+                    Section {
+                        ForEach(Array(updater.notices.enumerated()), id: \.offset) { _, notice in
+                            Text(notice.message)
+                                .foregroundStyle(notice.level == "warning" ? .orange : .secondary)
+                        }
                     }
                 }
                 ForEach(updater.releases.filter({ $0 != updater.state.release }), id: \.tagName) { release in
@@ -279,6 +297,11 @@ struct ReleaseRow: View {
                 }
             }
             if showChangelog {
+                if let policyMessage = release.policy?.message {
+                    Text(policyMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
                 LocalizedChangelogView(release: release)
                     .id(release.htmlUrl)
             }

--- a/Sources/AppUpdater/ManagedReleaseProvider.swift
+++ b/Sources/AppUpdater/ManagedReleaseProvider.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Version
+
+public struct ManagedReleaseFeed: Decodable {
+    public struct App: Decodable, Equatable {
+        public let id: String
+        public let name: String
+        public let platform: String
+    }
+
+    public struct CurrentVersion: Decodable, Equatable {
+        public let tagName: String
+        public let isLatest: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case tagName = "tag_name"
+            case isLatest = "is_latest"
+        }
+    }
+
+    public struct Latest: Decodable, Equatable {
+        public let tagName: String
+        public let name: String
+        public let publishedAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case tagName = "tag_name"
+            case name
+            case publishedAt = "published_at"
+        }
+    }
+
+    public struct Entitlement: Decodable, Equatable {
+        public struct CTA: Decodable, Equatable {
+            public let code: String
+            public let label: String
+            public let url: String
+        }
+
+        public let plan: String
+        public let licenseModel: String
+        public let memberFeaturesActive: Bool
+        public let memberFeaturesEndAt: String?
+        public let statusCode: String
+        public let statusMessage: String
+        public let cta: CTA?
+
+        enum CodingKeys: String, CodingKey {
+            case plan
+            case licenseModel = "license_model"
+            case memberFeaturesActive = "member_features_active"
+            case memberFeaturesEndAt = "member_features_end_at"
+            case statusCode = "status_code"
+            case statusMessage = "status_message"
+            case cta
+        }
+    }
+
+    public struct Notice: Decodable, Equatable {
+        public let level: String
+        public let code: String
+        public let message: String
+    }
+
+    public let serverTime: String?
+    public let app: App?
+    public let currentVersion: CurrentVersion?
+    public let latest: Latest?
+    public let entitlement: Entitlement?
+    public let releases: [Release]
+    public let notices: [Notice]
+
+    enum CodingKeys: String, CodingKey {
+        case serverTime = "server_time"
+        case app
+        case currentVersion = "current_version"
+        case latest
+        case entitlement
+        case releases
+        case notices
+    }
+}
+
+public struct ManagedReleasePolicy: Decodable, Equatable {
+    public let installAllowed: Bool
+    public let memberFeaturesActiveAfterInstall: Bool
+    public let code: String
+    public let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case installAllowed = "install_allowed"
+        case memberFeaturesActiveAfterInstall = "member_features_active_after_install"
+        case code
+        case message
+    }
+}
+
+public struct ManagedAPIError: Decodable, Swift.Error, Equatable {
+    public let code: String
+    public let message: String
+}
+
+public protocol ManagedReleaseFeedProviding: ReleaseProvider {
+    var lastFeed: ManagedReleaseFeed? { get }
+}
+
+private struct ManagedReleaseFeedEnvelope: Decodable {
+    let success: Bool
+    let data: ManagedReleaseFeed?
+    let error: ManagedAPIError?
+}
+
+private struct ManagedReleaseFeedRequest: Encodable {
+    let license: String?
+    let currentVersion: String?
+    let deviceId: String?
+    let platform: String
+
+    enum CodingKeys: String, CodingKey {
+        case license
+        case currentVersion = "current_version"
+        case deviceId = "device_id"
+        case platform
+    }
+}
+
+public final class ManagedReleaseProvider: ManagedReleaseFeedProviding {
+    public typealias StringProvider = () -> String?
+
+    public enum Error: Swift.Error {
+        case missingFeedData
+    }
+
+    public private(set) var lastFeed: ManagedReleaseFeed?
+
+    private let feedURL: URL
+    private let licenseProvider: StringProvider
+    private let currentVersionProvider: StringProvider
+    private let deviceIdProvider: StringProvider
+    private let platform: String
+    private let additionalHeaders: [String: String]
+    private let session: URLSession
+
+    public init(
+        feedURL: URL,
+        licenseProvider: @escaping StringProvider = { nil },
+        currentVersionProvider: @escaping StringProvider = {
+            let version = Bundle.main.version.description
+            return version == "null" ? nil : version
+        },
+        deviceIdProvider: @escaping StringProvider = { nil },
+        platform: String = "macos",
+        additionalHeaders: [String: String] = [:],
+        session: URLSession = .shared
+    ) {
+        self.feedURL = feedURL
+        self.licenseProvider = licenseProvider
+        self.currentVersionProvider = currentVersionProvider
+        self.deviceIdProvider = deviceIdProvider
+        self.platform = platform
+        self.additionalHeaders = additionalHeaders
+        self.session = session
+    }
+
+    public func fetchReleases(owner: String, repo: String, proxy: URLRequestProxy?) async throws -> [Release] {
+        var request = URLRequest(url: feedURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        additionalHeaders.forEach { key, value in
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        request.httpBody = try JSONEncoder().encode(ManagedReleaseFeedRequest(
+            license: licenseProvider(),
+            currentVersion: currentVersionProvider(),
+            deviceId: deviceIdProvider(),
+            platform: platform
+        ))
+
+        guard let result = try await session.dataTask(with: request, proxy: proxy) else {
+            throw AUError.invalidCallingConvention
+        }
+
+        if let envelope = try? JSONDecoder().decode(ManagedReleaseFeedEnvelope.self, from: result.data) {
+            guard envelope.success, let data = envelope.data else {
+                throw envelope.error ?? Error.missingFeedData
+            }
+            _ = try result.validate()
+            lastFeed = data
+            return data.releases
+        }
+
+        _ = try result.validate()
+        throw Error.missingFeedData
+    }
+
+    public func download(asset: Release.Asset, to saveLocation: URL, proxy: URLRequestProxy?) async throws -> AsyncThrowingStream<DownloadingState, Swift.Error> {
+        try await session.downloadTask(with: asset.downloadUrl, to: saveLocation, proxy: proxy)
+    }
+
+    public func fetchAssetData(asset: Release.Asset, proxy: URLRequestProxy?) async throws -> Data {
+        guard let result = try await session.dataTask(with: asset.downloadUrl, proxy: proxy)?.validate() else {
+            throw AUError.invalidCallingConvention
+        }
+        return result.data
+    }
+}

--- a/Tests/AppUpdaterTests/ManagedReleaseProviderTests.swift
+++ b/Tests/AppUpdaterTests/ManagedReleaseProviderTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+@testable import AppUpdater
+
+final class ManagedReleaseProviderTests: XCTestCase {
+    override class func setUp() {
+        super.setUp()
+        URLProtocol.registerClass(MockURLProtocol.self)
+    }
+
+    override class func tearDown() {
+        URLProtocol.unregisterClass(MockURLProtocol.self)
+        super.tearDown()
+    }
+
+    func testFetchReleasesDecodesManagedFeedAndCapturesEntitlement() async throws {
+        let responseBody = """
+        {
+          "success": true,
+          "data": {
+            "server_time": "2026-03-09T10:30:00.000Z",
+            "app": {
+              "id": "screensage-macos",
+              "name": "ScreenSage",
+              "platform": "macos"
+            },
+            "current_version": {
+              "tag_name": "1.7.0",
+              "is_latest": false
+            },
+            "latest": {
+              "tag_name": "1.8.0",
+              "name": "ScreenSage 1.8.0",
+              "published_at": "2026-03-08T16:00:00.000Z"
+            },
+            "entitlement": {
+              "plan": "free",
+              "license_model": "free",
+              "member_features_active": false,
+              "member_features_end_at": null,
+              "status_code": "FREE_FEATURES_LOCKED",
+              "status_message": "You can update to the latest version, but member-only features require an active membership.",
+              "cta": {
+                "code": "UPGRADE_MEMBERSHIP",
+                "label": "Upgrade",
+                "url": "https://screensage.pro/buy"
+              }
+            },
+            "releases": [
+              {
+                "tag_name": "1.8.0",
+                "name": "ScreenSage 1.8.0",
+                "body": "- Added batch OCR",
+                "html_url": "https://github.com/example/screensage/releases/tag/1.8.0",
+                "published_at": "2026-03-08T16:00:00.000Z",
+                "prerelease": false,
+                "assets": [
+                  {
+                    "name": "ScreenSage-1.8.0.zip",
+                    "content_type": "application/zip",
+                    "size": 123,
+                    "browser_download_url": "https://example.com/ScreenSage-1.8.0.zip"
+                  }
+                ],
+                "policy": {
+                  "install_allowed": true,
+                  "member_features_active_after_install": false,
+                  "code": "INSTALL_ALLOWED_FEATURES_LOCKED",
+                  "message": "This version can be installed, but member-only features will remain locked after installation."
+                }
+              }
+            ],
+            "notices": [
+              {
+                "level": "info",
+                "code": "UPDATE_AVAILABLE",
+                "message": "A newer version is available."
+              }
+            ]
+          },
+          "error": null
+        }
+        """
+
+        let session = makeSession { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.absoluteString, "https://example.com/feed")
+            let body = try XCTUnwrap(Self.requestBody(from: request))
+            let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+            XCTAssertEqual(json?["license"] as? String, "LIC-123")
+            XCTAssertEqual(json?["current_version"] as? String, "1.7.0")
+            XCTAssertEqual(json?["device_id"] as? String, "device-1")
+            XCTAssertEqual(json?["platform"] as? String, "macos")
+            return HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
+        } dataProvider: {
+            Data(responseBody.utf8)
+        }
+
+        let provider = ManagedReleaseProvider(
+            feedURL: try XCTUnwrap(URL(string: "https://example.com/feed")),
+            licenseProvider: { "LIC-123" },
+            currentVersionProvider: { "1.7.0" },
+            deviceIdProvider: { "device-1" },
+            session: session
+        )
+
+        let releases = try await provider.fetchReleases(owner: "ignored", repo: "ignored", proxy: nil)
+        XCTAssertEqual(releases.count, 1)
+        XCTAssertEqual(releases.first?.tagName.description, "1.8.0")
+        XCTAssertEqual(releases.first?.policy?.code, "INSTALL_ALLOWED_FEATURES_LOCKED")
+        XCTAssertEqual(provider.lastFeed?.entitlement?.statusCode, "FREE_FEATURES_LOCKED")
+        XCTAssertEqual(provider.lastFeed?.notices.first?.code, "UPDATE_AVAILABLE")
+    }
+
+    func testFetchReleasesThrowsManagedAPIError() async throws {
+        let responseBody = """
+        {
+          "success": false,
+          "data": null,
+          "error": {
+            "code": "LICENSE_INVALID",
+            "message": "The provided license key is invalid."
+          }
+        }
+        """
+
+        let session = makeSession { request in
+            HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
+        } dataProvider: {
+            Data(responseBody.utf8)
+        }
+
+        let provider = ManagedReleaseProvider(
+            feedURL: try XCTUnwrap(URL(string: "https://example.com/feed")),
+            session: session
+        )
+
+        do {
+            _ = try await provider.fetchReleases(owner: "ignored", repo: "ignored", proxy: nil)
+            XCTFail("Expected fetchReleases to throw")
+        } catch let error as ManagedAPIError {
+            XCTAssertEqual(error.code, "LICENSE_INVALID")
+            XCTAssertEqual(error.message, "The provided license key is invalid.")
+        }
+    }
+
+    private func makeSession(
+        responseProvider: @escaping (URLRequest) throws -> HTTPURLResponse,
+        dataProvider: @escaping () -> Data
+    ) -> URLSession {
+        MockURLProtocol.responseProvider = responseProvider
+        MockURLProtocol.dataProvider = dataProvider
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private static func requestBody(from request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+        stream.open()
+        defer { stream.close() }
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        let data = NSMutableData()
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read <= 0 { break }
+            data.append(buffer, length: read)
+        }
+        return data as Data
+    }
+}
+
+private final class MockURLProtocol: URLProtocol {
+    static var responseProvider: ((URLRequest) throws -> HTTPURLResponse)?
+    static var dataProvider: (() -> Data)?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        do {
+            guard let responseProvider = Self.responseProvider else {
+                throw NSError(domain: "MockURLProtocol", code: 1)
+            }
+            let response = try responseProvider(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = Self.dataProvider?() {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/AppUpdaterTests/ManagedReleaseProviderTests.swift
+++ b/Tests/AppUpdaterTests/ManagedReleaseProviderTests.swift
@@ -12,75 +12,145 @@ final class ManagedReleaseProviderTests: XCTestCase {
         super.tearDown()
     }
 
-    func testFetchReleasesDecodesManagedFeedAndCapturesEntitlement() async throws {
-        let responseBody = """
-        {
-          "success": true,
-          "data": {
-            "server_time": "2026-03-09T10:30:00.000Z",
-            "app": {
-              "id": "screensage-macos",
-              "name": "ScreenSage",
-              "platform": "macos"
-            },
-            "current_version": {
-              "tag_name": "1.7.0",
-              "is_latest": false
-            },
-            "latest": {
-              "tag_name": "1.8.0",
-              "name": "ScreenSage 1.8.0",
-              "published_at": "2026-03-08T16:00:00.000Z"
-            },
-            "entitlement": {
-              "plan": "free",
-              "license_model": "free",
-              "member_features_active": false,
-              "member_features_end_at": null,
-              "status_code": "FREE_FEATURES_LOCKED",
-              "status_message": "You can update to the latest version, but member-only features require an active membership.",
-              "cta": {
-                "code": "UPGRADE_MEMBERSHIP",
-                "label": "Upgrade",
-                "url": "https://screensage.pro/buy"
-              }
-            },
-            "releases": [
-              {
-                "tag_name": "1.8.0",
-                "name": "ScreenSage 1.8.0",
-                "body": "- Added batch OCR",
-                "html_url": "https://github.com/example/screensage/releases/tag/1.8.0",
-                "published_at": "2026-03-08T16:00:00.000Z",
-                "prerelease": false,
-                "assets": [
-                  {
-                    "name": "ScreenSage-1.8.0.zip",
-                    "content_type": "application/zip",
-                    "size": 123,
-                    "browser_download_url": "https://example.com/ScreenSage-1.8.0.zip"
-                  }
+    func testFreeUserFeedShowsLockedPremiumFeatures() async throws {
+        let provider = makeProvider(responseBody: makeFeedResponse(
+            entitlement: [
+                "plan": "free",
+                "license_model": "free",
+                "member_features_active": false,
+                "member_features_end_at": NSNull(),
+                "status_code": "FREE_FEATURES_LOCKED",
+                "status_message": "You can update to the latest version, but member-only features require an active membership.",
+                "cta": [
+                    "code": "UPGRADE_MEMBERSHIP",
+                    "label": "Upgrade",
+                    "url": "https://screensage.pro/buy",
                 ],
-                "policy": {
-                  "install_allowed": true,
-                  "member_features_active_after_install": false,
-                  "code": "INSTALL_ALLOWED_FEATURES_LOCKED",
-                  "message": "This version can be installed, but member-only features will remain locked after installation."
-                }
-              }
             ],
-            "notices": [
-              {
+            notices: [[
                 "level": "info",
                 "code": "UPDATE_AVAILABLE",
-                "message": "A newer version is available."
-              }
+                "message": "A newer version is available.",
+            ]],
+            releasePolicy: [
+                "install_allowed": true,
+                "member_features_active_after_install": false,
+                "code": "INSTALL_ALLOWED_FEATURES_LOCKED",
+                "message": "This version can be installed, but member-only features will remain locked after installation.",
             ]
-          },
-          "error": null
-        }
-        """
+        ))
 
+        let releases = try await provider.fetchReleases(owner: "ignored", repo: "ignored", proxy: nil)
+        XCTAssertEqual(releases.count, 1)
+        XCTAssertEqual(releases.first?.policy?.code, "INSTALL_ALLOWED_FEATURES_LOCKED")
+        XCTAssertEqual(provider.lastFeed?.entitlement?.statusCode, "FREE_FEATURES_LOCKED")
+        XCTAssertEqual(provider.lastFeed?.entitlement?.cta?.code, "UPGRADE_MEMBERSHIP")
+        XCTAssertEqual(provider.lastFeed?.notices.first?.code, "UPDATE_AVAILABLE")
+    }
+
+    func testActiveSubscriberFeedKeepsFeaturesAvailable() async throws {
+        let provider = makeProvider(responseBody: makeFeedResponse(
+            entitlement: [
+                "plan": "pro",
+                "license_model": "subscription",
+                "member_features_active": true,
+                "member_features_end_at": "2026-06-01T00:00:00.000Z",
+                "status_code": "MEMBER_FEATURES_ACTIVE",
+                "status_message": "You can update to the latest version and member-only features are currently active.",
+                "cta": [
+                    "code": "MANAGE_MEMBERSHIP",
+                    "label": "Manage",
+                    "url": "https://screensage.pro/p",
+                ],
+            ],
+            notices: [[
+                "level": "info",
+                "code": "UPDATE_AVAILABLE",
+                "message": "A newer version is available.",
+            ]],
+            releasePolicy: [
+                "install_allowed": true,
+                "member_features_active_after_install": true,
+                "code": "INSTALL_ALLOWED_FEATURES_ACTIVE",
+                "message": "This version can be installed and member-only features will remain active after installation.",
+            ]
+        ))
+
+        let releases = try await provider.fetchReleases(owner: "ignored", repo: "ignored", proxy: nil)
+        XCTAssertEqual(releases.first?.policy?.code, "INSTALL_ALLOWED_FEATURES_ACTIVE")
+        XCTAssertEqual(provider.lastFeed?.entitlement?.memberFeaturesActive, true)
+        XCTAssertEqual(provider.lastFeed?.entitlement?.statusCode, "MEMBER_FEATURES_ACTIVE")
+    }
+
+    func testExpiredSubscriberFeedStillAllowsInstallButPromptsRenewal() async throws {
+        let provider = makeProvider(responseBody: makeFeedResponse(
+            entitlement: [
+                "plan": "pro",
+                "license_model": "subscription",
+                "member_features_active": false,
+                "member_features_end_at": "2026-03-01T00:00:00.000Z",
+                "status_code": "MEMBER_FEATURES_EXPIRED",
+                "status_message": "You can update to the latest version, but member-only features have expired and require renewal.",
+                "cta": [
+                    "code": "RENEW_MEMBERSHIP",
+                    "label": "Renew",
+                    "url": "https://screensage.pro/buy",
+                ],
+            ],
+            notices: [[
+                "level": "warning",
+                "code": "MEMBERSHIP_EXPIRED_AFTER_INSTALL",
+                "message": "The app can be updated, but member-only features are currently unavailable.",
+            ]],
+            releasePolicy: [
+                "install_allowed": true,
+                "member_features_active_after_install": false,
+                "code": "INSTALL_ALLOWED_FEATURES_EXPIRED",
+                "message": "This version can be installed, but member-only features will remain unavailable until the membership is renewed.",
+            ]
+        ))
+
+        let releases = try await provider.fetchReleases(owner: "ignored", repo: "ignored", proxy: nil)
+        XCTAssertEqual(releases.first?.policy?.code, "INSTALL_ALLOWED_FEATURES_EXPIRED")
+        XCTAssertEqual(provider.lastFeed?.entitlement?.statusCode, "MEMBER_FEATURES_EXPIRED")
+        XCTAssertEqual(provider.lastFeed?.entitlement?.cta?.code, "RENEW_MEMBERSHIP")
+        XCTAssertEqual(provider.lastFeed?.notices.first?.code, "MEMBERSHIP_EXPIRED_AFTER_INSTALL")
+    }
+
+    func testPerpetualMemberFeedHasNoFeatureExpiry() async throws {
+        let provider = makeProvider(responseBody: makeFeedResponse(
+            entitlement: [
+                "plan": "lifetime",
+                "license_model": "perpetual",
+                "member_features_active": true,
+                "member_features_end_at": NSNull(),
+                "status_code": "MEMBER_FEATURES_ACTIVE",
+                "status_message": "You can update to the latest version and member-only features are currently active.",
+                "cta": [
+                    "code": "MANAGE_MEMBERSHIP",
+                    "label": "Manage",
+                    "url": "https://screensage.pro/p",
+                ],
+            ],
+            notices: [[
+                "level": "info",
+                "code": "ALREADY_UP_TO_DATE",
+                "message": "You are already using the latest version.",
+            ]],
+            releasePolicy: [
+                "install_allowed": true,
+                "member_features_active_after_install": true,
+                "code": "INSTALL_ALLOWED_FEATURES_ACTIVE",
+                "message": "This version can be installed and member-only features will remain active after installation.",
+            ]
+        ))
+
+        _ = try await provider.fetchReleases(owner: "ignored", repo: "ignored", proxy: nil)
+        XCTAssertNil(provider.lastFeed?.entitlement?.memberFeaturesEndAt)
+        XCTAssertEqual(provider.lastFeed?.notices.first?.code, "ALREADY_UP_TO_DATE")
+    }
+
+    func testFetchReleasesSendsExpectedRequestPayload() async throws {
         let session = makeSession { request in
             XCTAssertEqual(request.httpMethod, "POST")
             XCTAssertEqual(request.url?.absoluteString, "https://example.com/feed")
@@ -92,7 +162,28 @@ final class ManagedReleaseProviderTests: XCTestCase {
             XCTAssertEqual(json?["platform"] as? String, "macos")
             return HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
         } dataProvider: {
-            Data(responseBody.utf8)
+            Data(self.makeFeedResponse(
+                entitlement: [
+                    "plan": "free",
+                    "license_model": "free",
+                    "member_features_active": false,
+                    "member_features_end_at": NSNull(),
+                    "status_code": "FREE_FEATURES_LOCKED",
+                    "status_message": "You can update to the latest version, but member-only features require an active membership.",
+                    "cta": [
+                        "code": "UPGRADE_MEMBERSHIP",
+                        "label": "Upgrade",
+                        "url": "https://screensage.pro/buy",
+                    ],
+                ],
+                notices: [],
+                releasePolicy: [
+                    "install_allowed": true,
+                    "member_features_active_after_install": false,
+                    "code": "INSTALL_ALLOWED_FEATURES_LOCKED",
+                    "message": "This version can be installed, but member-only features will remain locked after installation.",
+                ]
+            ).utf8)
         }
 
         let provider = ManagedReleaseProvider(
@@ -103,12 +194,7 @@ final class ManagedReleaseProviderTests: XCTestCase {
             session: session
         )
 
-        let releases = try await provider.fetchReleases(owner: "ignored", repo: "ignored", proxy: nil)
-        XCTAssertEqual(releases.count, 1)
-        XCTAssertEqual(releases.first?.tagName.description, "1.8.0")
-        XCTAssertEqual(releases.first?.policy?.code, "INSTALL_ALLOWED_FEATURES_LOCKED")
-        XCTAssertEqual(provider.lastFeed?.entitlement?.statusCode, "FREE_FEATURES_LOCKED")
-        XCTAssertEqual(provider.lastFeed?.notices.first?.code, "UPDATE_AVAILABLE")
+        _ = try await provider.fetchReleases(owner: "ignored", repo: "ignored", proxy: nil)
     }
 
     func testFetchReleasesThrowsManagedAPIError() async throws {
@@ -141,6 +227,70 @@ final class ManagedReleaseProviderTests: XCTestCase {
             XCTAssertEqual(error.code, "LICENSE_INVALID")
             XCTAssertEqual(error.message, "The provided license key is invalid.")
         }
+    }
+
+    private func makeProvider(responseBody: String) -> ManagedReleaseProvider {
+        let session = makeSession { request in
+            HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
+        } dataProvider: {
+            Data(responseBody.utf8)
+        }
+
+        return ManagedReleaseProvider(
+            feedURL: URL(string: "https://example.com/feed")!,
+            licenseProvider: { "LIC-123" },
+            currentVersionProvider: { "1.7.0" },
+            deviceIdProvider: { "device-1" },
+            session: session
+        )
+    }
+
+    private func makeFeedResponse(
+        entitlement: [String: Any],
+        notices: [[String: Any]],
+        releasePolicy: [String: Any]
+    ) -> String {
+        let body: [String: Any] = [
+            "success": true,
+            "data": [
+                "server_time": "2026-03-09T10:30:00.000Z",
+                "app": [
+                    "id": "screensage-macos",
+                    "name": "ScreenSage",
+                    "platform": "macos",
+                ],
+                "current_version": [
+                    "tag_name": "1.7.0",
+                    "is_latest": false,
+                ],
+                "latest": [
+                    "tag_name": "1.8.0",
+                    "name": "ScreenSage 1.8.0",
+                    "published_at": "2026-03-08T16:00:00.000Z",
+                ],
+                "entitlement": entitlement,
+                "releases": [[
+                    "tag_name": "1.8.0",
+                    "name": "ScreenSage 1.8.0",
+                    "body": "- Added batch OCR",
+                    "html_url": "https://github.com/example/screensage/releases/tag/1.8.0",
+                    "published_at": "2026-03-08T16:00:00.000Z",
+                    "prerelease": false,
+                    "assets": [[
+                        "name": "ScreenSage-1.8.0.zip",
+                        "content_type": "application/zip",
+                        "size": 123,
+                        "browser_download_url": "https://example.com/ScreenSage-1.8.0.zip",
+                    ]],
+                    "policy": releasePolicy,
+                ]],
+                "notices": notices,
+            ],
+            "error": NSNull(),
+        ]
+
+        let data = try! JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
     }
 
     private func makeSession(

--- a/docs/managed-feed-provider.md
+++ b/docs/managed-feed-provider.md
@@ -65,21 +65,112 @@ The backend still returns the standard envelope:
 - `notices` is exposed as `updater.notices`
 - `policy` is attached to each `Release`, so your existing update settings UI can show post-install membership messaging
 
+## App integration checklist
+
+A host app usually only needs these steps:
+
+1. keep a stable backend feed URL, such as `/api/public/app-updates/feed`
+2. provide the current license key with `licenseProvider`
+3. provide a stable device identifier with `deviceIdProvider`
+4. optionally override `currentVersionProvider` if your app version source is not `Bundle.main.version`
+5. call `updater.check()` the same way as before
+6. localize `entitlement.statusCode`, `policy.code`, and `notices[*].code` in the app layer
+7. open `cta.url` from your own purchase or membership management flow
+
 ## Typical setup
 
 ```swift
-let updater = AppUpdater(
-    owner: "ignored",
-    repo: "ignored",
-    provider: ManagedReleaseProvider(
-        feedURL: URL(string: "https://example.com/api/public/app-updates/feed")!,
-        licenseProvider: { licenseKey },
-        currentVersionProvider: { Bundle.main.version.description },
-        deviceIdProvider: { deviceId },
-        platform: "macos"
-    )
-)
+final class UpdateCenter: ObservableObject {
+    static let shared = UpdateCenter()
+
+    let updater: AppUpdater
+
+    private init() {
+        updater = AppUpdater(
+            owner: "ignored",
+            repo: "ignored",
+            provider: ManagedReleaseProvider(
+                feedURL: URL(string: "https://example.com/api/public/app-updates/feed")!,
+                licenseProvider: { LicenseStore.shared.currentKey },
+                currentVersionProvider: { Bundle.main.version.description },
+                deviceIdProvider: { DeviceIdentity.shared.stableDeviceID },
+                platform: "macos"
+            )
+        )
+    }
+}
 ```
+
+## SwiftUI host example
+
+```swift
+struct UpdatesView: View {
+    @EnvironmentObject var updater: AppUpdater
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let entitlement = updater.entitlement {
+                Text(localizedEntitlementText(for: entitlement.statusCode))
+                Text(entitlement.statusMessage)
+                    .foregroundStyle(.secondary)
+            }
+
+            ForEach(updater.notices, id: \.code) { notice in
+                Text(localizedNoticeText(for: notice.code))
+            }
+
+            if let release = updater.state.release,
+               let policy = release.policy {
+                Text(localizedPolicyText(for: policy.code))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button("Check for Updates") {
+                updater.check()
+            }
+        }
+    }
+}
+```
+
+## Localization strategy
+
+Use `code` as the primary UI switch and `message` as a fallback.
+
+Recommended order:
+
+1. inspect the `code`
+2. map it to local app copy
+3. fall back to the backend-provided `message` only if the app has no local mapping yet
+
+Typical examples:
+
+- `entitlement.statusCode`
+  - `MEMBER_FEATURES_ACTIVE`
+  - `MEMBER_FEATURES_EXPIRED`
+  - `FREE_FEATURES_LOCKED`
+- `release.policy.code`
+  - `INSTALL_ALLOWED_FEATURES_ACTIVE`
+  - `INSTALL_ALLOWED_FEATURES_EXPIRED`
+  - `INSTALL_ALLOWED_FEATURES_LOCKED`
+- `notices[*].code`
+  - `UPDATE_AVAILABLE`
+  - `ALREADY_UP_TO_DATE`
+  - `MEMBERSHIP_EXPIRED_AFTER_INSTALL`
+
+## Device ID guidance
+
+`deviceIdProvider` should return a stable identifier for the current machine.
+
+Recommended characteristics:
+
+- stable across app relaunches
+- different across different machines
+- stored in Keychain or another durable app-owned store
+- not re-generated on every launch
+
+If you already have a device activation system, reuse the same device ID here.
 
 ## App-layer responsibilities
 

--- a/docs/managed-feed-provider.md
+++ b/docs/managed-feed-provider.md
@@ -1,0 +1,98 @@
+# Managed Feed Provider
+
+`ManagedReleaseProvider` is the integration mode for apps that want to keep AppUpdater's existing download and install flow, while moving release selection and membership messaging to their own backend.
+
+## When to use it
+
+Use this provider when:
+
+- your app still ships update archives through GitHub Releases or another public file host
+- your backend needs to decide what membership or entitlement message the user should see
+- you want to show all release notes, even when premium features are inactive
+- you want AppUpdater to stay as the update engine, instead of rebuilding update UI logic in the app layer
+
+## What the backend should return
+
+The backend still returns the standard envelope:
+
+```json
+{
+  "success": true,
+  "data": {
+    "latest": { "tag_name": "1.8.0" },
+    "entitlement": {
+      "status_code": "FREE_FEATURES_LOCKED",
+      "status_message": "You can update to the latest version, but member-only features require an active membership."
+    },
+    "releases": [
+      {
+        "tag_name": "1.8.0",
+        "name": "ScreenSage 1.8.0",
+        "body": "- Added batch OCR",
+        "html_url": "https://github.com/example/app/releases/tag/1.8.0",
+        "prerelease": false,
+        "assets": [
+          {
+            "name": "ScreenSage-1.8.0.zip",
+            "content_type": "application/zip",
+            "browser_download_url": "https://github.com/example/app/releases/download/1.8.0/ScreenSage-1.8.0.zip"
+          }
+        ],
+        "policy": {
+          "install_allowed": true,
+          "member_features_active_after_install": false,
+          "code": "INSTALL_ALLOWED_FEATURES_LOCKED",
+          "message": "This version can be installed, but member-only features will remain locked after installation."
+        }
+      }
+    ],
+    "notices": [
+      {
+        "level": "info",
+        "code": "UPDATE_AVAILABLE",
+        "message": "A newer version is available."
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+## What AppUpdater does with it
+
+- `data.releases` is decoded into the normal `Release` model
+- `entitlement` is exposed as `updater.entitlement`
+- `notices` is exposed as `updater.notices`
+- `policy` is attached to each `Release`, so your existing update settings UI can show post-install membership messaging
+
+## Typical setup
+
+```swift
+let updater = AppUpdater(
+    owner: "ignored",
+    repo: "ignored",
+    provider: ManagedReleaseProvider(
+        feedURL: URL(string: "https://example.com/api/public/app-updates/feed")!,
+        licenseProvider: { licenseKey },
+        currentVersionProvider: { Bundle.main.version.description },
+        deviceIdProvider: { deviceId },
+        platform: "macos"
+    )
+)
+```
+
+## App-layer responsibilities
+
+The app layer usually only needs to:
+
+- provide `license`, `deviceId`, and optionally `currentVersion`
+- localize `entitlement.statusCode`, `policy.code`, and `notices[*].code`
+- decide where `cta.url` should open in your UI
+
+The app layer does **not** need to reimplement release selection, archive download, or installation.
+
+## Notes
+
+- release assets should still follow AppUpdater's normal archive expectations
+- the backend can point asset URLs to GitHub Releases, R2, or any other downloadable archive host
+- this mode is intended for apps where update availability and premium-feature availability are separate concerns

--- a/docs/managed-feed-provider.zh.md
+++ b/docs/managed-feed-provider.zh.md
@@ -68,21 +68,112 @@
 - `notices` 会暴露为 `updater.notices`
 - `policy` 会挂在每个 `Release` 上，便于在现有更新 UI 中展示“安装后会员功能是否可用”
 
+## App 端接入清单
+
+一个宿主 App 通常只需要完成这些步骤：
+
+1. 准备固定的后端 feed URL，例如 `/api/public/app-updates/feed`
+2. 通过 `licenseProvider` 提供当前 license key
+3. 通过 `deviceIdProvider` 提供稳定的设备 ID
+4. 如果你的版本来源不是 `Bundle.main.version`，再覆盖 `currentVersionProvider`
+5. 像以前一样调用 `updater.check()`
+6. 在 App 层对 `entitlement.statusCode`、`policy.code`、`notices[*].code` 做本地化
+7. 根据你的产品流打开 `cta.url`
+
 ## 典型初始化方式
 
 ```swift
-let updater = AppUpdater(
-    owner: "ignored",
-    repo: "ignored",
-    provider: ManagedReleaseProvider(
-        feedURL: URL(string: "https://example.com/api/public/app-updates/feed")!,
-        licenseProvider: { licenseKey },
-        currentVersionProvider: { Bundle.main.version.description },
-        deviceIdProvider: { deviceId },
-        platform: "macos"
-    )
-)
+final class UpdateCenter: ObservableObject {
+    static let shared = UpdateCenter()
+
+    let updater: AppUpdater
+
+    private init() {
+        updater = AppUpdater(
+            owner: "ignored",
+            repo: "ignored",
+            provider: ManagedReleaseProvider(
+                feedURL: URL(string: "https://example.com/api/public/app-updates/feed")!,
+                licenseProvider: { LicenseStore.shared.currentKey },
+                currentVersionProvider: { Bundle.main.version.description },
+                deviceIdProvider: { DeviceIdentity.shared.stableDeviceID },
+                platform: "macos"
+            )
+        )
+    }
+}
 ```
+
+## SwiftUI 宿主示例
+
+```swift
+struct UpdatesView: View {
+    @EnvironmentObject var updater: AppUpdater
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let entitlement = updater.entitlement {
+                Text(localizedEntitlementText(for: entitlement.statusCode))
+                Text(entitlement.statusMessage)
+                    .foregroundStyle(.secondary)
+            }
+
+            ForEach(updater.notices, id: \.code) { notice in
+                Text(localizedNoticeText(for: notice.code))
+            }
+
+            if let release = updater.state.release,
+               let policy = release.policy {
+                Text(localizedPolicyText(for: policy.code))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button("Check for Updates") {
+                updater.check()
+            }
+        }
+    }
+}
+```
+
+## 本地化建议
+
+建议把 `code` 作为主判断字段，把 `message` 作为兜底文案。
+
+推荐顺序：
+
+1. 先读取 `code`
+2. 在 App 内映射为本地化文案
+3. 如果本地还没有这个映射，再退回到后端给的 `message`
+
+典型字段包括：
+
+- `entitlement.statusCode`
+  - `MEMBER_FEATURES_ACTIVE`
+  - `MEMBER_FEATURES_EXPIRED`
+  - `FREE_FEATURES_LOCKED`
+- `release.policy.code`
+  - `INSTALL_ALLOWED_FEATURES_ACTIVE`
+  - `INSTALL_ALLOWED_FEATURES_EXPIRED`
+  - `INSTALL_ALLOWED_FEATURES_LOCKED`
+- `notices[*].code`
+  - `UPDATE_AVAILABLE`
+  - `ALREADY_UP_TO_DATE`
+  - `MEMBERSHIP_EXPIRED_AFTER_INSTALL`
+
+## 设备 ID 建议
+
+`deviceIdProvider` 应返回当前机器的稳定标识。
+
+推荐特征：
+
+- App 重启后保持不变
+- 不同机器之间不同
+- 存储在 Keychain 或其他持久化位置
+- 不要每次启动都重新生成
+
+如果你的应用已经有设备激活系统，建议直接复用同一个设备 ID。
 
 ## App 层通常还需要做什么
 

--- a/docs/managed-feed-provider.zh.md
+++ b/docs/managed-feed-provider.zh.md
@@ -1,0 +1,101 @@
+# Managed Feed Provider
+
+`ManagedReleaseProvider` 适用于这样一种接入方式：
+
+- 继续使用 AppUpdater 现有的下载、校验、安装流程
+- 但把 release 列表、会员状态说明、安装后权限提示交给自己的后端返回
+
+## 适用场景
+
+当你的应用满足以下情况时，推荐使用这个模式：
+
+- 安装包仍然放在 GitHub Releases 或其他公共下载源
+- 你的后端需要决定用户应看到什么会员/权限提示
+- 即使会员功能不可用，仍然希望用户看到所有版本和更新日志
+- 希望把更新引擎继续留在 AppUpdater，而不是在 App 层重写一套更新逻辑
+
+## 后端返回什么
+
+后端仍然返回标准的 `{ success, data, error }` 包装结构：
+
+```json
+{
+  "success": true,
+  "data": {
+    "latest": { "tag_name": "1.8.0" },
+    "entitlement": {
+      "status_code": "FREE_FEATURES_LOCKED",
+      "status_message": "You can update to the latest version, but member-only features require an active membership."
+    },
+    "releases": [
+      {
+        "tag_name": "1.8.0",
+        "name": "ScreenSage 1.8.0",
+        "body": "- Added batch OCR",
+        "html_url": "https://github.com/example/app/releases/tag/1.8.0",
+        "prerelease": false,
+        "assets": [
+          {
+            "name": "ScreenSage-1.8.0.zip",
+            "content_type": "application/zip",
+            "browser_download_url": "https://github.com/example/app/releases/download/1.8.0/ScreenSage-1.8.0.zip"
+          }
+        ],
+        "policy": {
+          "install_allowed": true,
+          "member_features_active_after_install": false,
+          "code": "INSTALL_ALLOWED_FEATURES_LOCKED",
+          "message": "This version can be installed, but member-only features will remain locked after installation."
+        }
+      }
+    ],
+    "notices": [
+      {
+        "level": "info",
+        "code": "UPDATE_AVAILABLE",
+        "message": "A newer version is available."
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+## AppUpdater 会怎么处理
+
+- `data.releases` 继续解码成正常的 `Release`
+- `entitlement` 会暴露为 `updater.entitlement`
+- `notices` 会暴露为 `updater.notices`
+- `policy` 会挂在每个 `Release` 上，便于在现有更新 UI 中展示“安装后会员功能是否可用”
+
+## 典型初始化方式
+
+```swift
+let updater = AppUpdater(
+    owner: "ignored",
+    repo: "ignored",
+    provider: ManagedReleaseProvider(
+        feedURL: URL(string: "https://example.com/api/public/app-updates/feed")!,
+        licenseProvider: { licenseKey },
+        currentVersionProvider: { Bundle.main.version.description },
+        deviceIdProvider: { deviceId },
+        platform: "macos"
+    )
+)
+```
+
+## App 层通常还需要做什么
+
+App 层通常只需要：
+
+- 提供 `license`、`deviceId`，以及可选的 `currentVersion`
+- 对 `entitlement.statusCode`、`policy.code`、`notices[*].code` 做本地化
+- 决定 `cta.url` 在你的 UI 中如何打开
+
+App 层通常**不需要**重新实现 release 选择、下载或安装逻辑。
+
+## 说明
+
+- release 资产命名仍应满足 AppUpdater 原有的归档格式要求
+- 后端返回的下载 URL 可以继续指向 GitHub Releases、R2 或其他下载源
+- 这个模式适合“App 可更新性”和“高级功能可用性”需要分开表达的产品


### PR DESCRIPTION
## Summary\n- add a managed release feed provider that reads  JSON from a backend endpoint\n- expose feed entitlement/notices on  and decode per-release policy metadata\n- add provider documentation and Swift tests covering successful and error feed responses\n\n## Testing\n- swift test\n